### PR TITLE
Release/0.3.0

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,23 @@
+name: Check Build
+
+on:
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Build
+        run: pnpm run prepack

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           node-version: 20
 
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 8
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Prepare Build
+        run: pnpm run prepack
+
       - name: Run Build
         run: pnpm run typecheck

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,0 +1,28 @@
+name: Check Types
+
+on:
+  pull_request: {}
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Build
+        run: pnpm run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run linting
+        run: pnpm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           node-version: 20
 
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 8
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/README.md
+++ b/README.md
@@ -77,19 +77,47 @@ App config:
 ```ts
 sentry: {
   sdk?: (app: NuxtApp) => SdkConfig | SdkConfig
-  integrations?: {
-    GlobalHandlers?: boolean | GlobalHandlersOptions
-    TryCatch?: boolean | TryCatchOptions
-    Breadcrumbs?: boolean | BreadcrumbsOptions
-    LinkedErrors?: boolean | LinkedErrorsOptions
-    HttpContext?: boolean 
-    Dedupe?: boolean
-    FunctionToString?: boolean
-    InboundFilters?: boolean | InboundFiltersOptions
-    Replay?: boolean | ReplayConfiguration
-    BrowserTracing?: boolean | BrowserTracingOptions
-    BrowserProfiling?: boolean
-  }
+  integrations?: IntegrationOptions
+}
+```
+
+`IntegrationOptions`:
+
+`true` enables the integration with default options.
+`false` disables the integration.
+
+The default integrations that are enabled are:
+- Breadcrumbs
+- Dedupe
+- FunctionToString
+- GlobalHandlers
+- HttpContext
+- InboundFilters
+- LinkedErrors
+- TryCatch
+
+```ts
+{
+  breadcrumbs?: boolean | BreadcrumbsOptions, // default: true
+  browserTracing?: boolean | BrowserTracingOptions,
+  browserProfiling?: boolean,
+  captureConsole?: boolean | CaptureConsoleOptions,
+  contextLines?: boolean | ContextLinesOptions,
+  debug?: boolean | DebugOptions,
+  dedupe?: boolean, // default: true
+  extraErrorData?: boolean | ExtraErrorDataOptions,
+  functionToString?: boolean, // default: true
+  globalHandlers?: boolean | GlobalHandlersOptions, // default: true
+  httpClient?: boolean | HttpClientOptions,
+  httpContext?: boolean, // default: true
+  inboundFilters?: boolean | InboundFiltersOptions, // default: true
+  linkedErrors?: boolean | LinkedErrorsOptions, // default: true
+  moduleMetadata?: boolean,
+  replay?: boolean | ReplayConfiguration,
+  reportingObserver?: boolean | ReportingObserverOptions,
+  rewriteFrames?: boolean | RewriteFramesOptions,
+  sessionTiming?: boolean,
+  tryCatch?: boolean | TryCatchOptions, // default: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ export default defineNuxtConfig({
 })
 ```
 
-> !NOTE: You can also use environment variables to set the DSN using `NUXT_PUBLIC_SENTRY_DSN`
+> [!NOTE]
+> You can also use environment variables to set the DSN using `NUXT_PUBLIC_SENTRY_DSN`
 
 That's it! You can now use Nuxt Sentry in your Nuxt app ✨
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ export default defineNuxtConfig({
 })
 ```
 
+> !NOTE: You can also use environment variables to set the DSN using `NUXT_PUBLIC_SENTRY_DSN`
+
 That's it! You can now use Nuxt Sentry in your Nuxt app ✨
 
 ## Configuration
@@ -45,48 +47,7 @@ The module can be configured by providing a `sentry` key in the `public` section
 
 The `sdk` object is passed directly to the Sentry SDK. It consists of the properties specified in the [Sentry documentation here](https://docs.sentry.io/platforms/javascript/configuration/options/).
 
-The `integration` object contains the properties specified in the [Sentry documentation here](https://docs.sentry.io/platforms/javascript/configuration/integrations/). For each integration, you can either pass `true` to enable it or an object to configure it. By default, the following integrations are enabled:
-- `BrowserTracing` (With the Vue integration enabled)
-- `Replay`
-
-Runtime config:
-
-```ts
-sentry: {
-  enabled?: boolean // Default: Enabled in production
-  dsn: string,
-  sdk?: SdkConfig
-  integrations?: {
-    GlobalHandlers?: boolean | GlobalHandlersOptions
-    TryCatch?: boolean | TryCatchOptions
-    Breadcrumbs?: boolean | BreadcrumbsOptions
-    LinkedErrors?: boolean | LinkedErrorsOptions
-    HttpContext?: boolean 
-    Dedupe?: boolean
-    FunctionToString?: boolean
-    InboundFilters?: boolean | InboundFiltersOptions
-    Replay?: boolean | ReplayConfiguration
-    BrowserTracing?: boolean | BrowserTracingOptions
-    BrowserProfiling?: boolean
-  }
-}
-```
-
-App config:
-
-```ts
-sentry: {
-  sdk?: (app: NuxtApp) => SdkConfig | SdkConfig
-  integrations?: IntegrationOptions
-}
-```
-
-`IntegrationOptions`:
-
-`true` enables the integration with default options.
-`false` disables the integration.
-
-The default integrations that are enabled are:
+The `disabledIntegrations` object takes a key of the integration name and a boolean value to enable or disable the integration. The default integrations that are enabled are:
 - Breadcrumbs
 - Dedupe
 - FunctionToString
@@ -96,29 +57,53 @@ The default integrations that are enabled are:
 - LinkedErrors
 - TryCatch
 
+Runtime config:
+
 ```ts
-{
-  breadcrumbs?: boolean | BreadcrumbsOptions, // default: true
-  browserTracing?: boolean | BrowserTracingOptions,
-  browserProfiling?: boolean,
-  captureConsole?: boolean | CaptureConsoleOptions,
-  contextLines?: boolean | ContextLinesOptions,
-  debug?: boolean | DebugOptions,
-  dedupe?: boolean, // default: true
-  extraErrorData?: boolean | ExtraErrorDataOptions,
-  functionToString?: boolean, // default: true
-  globalHandlers?: boolean | GlobalHandlersOptions, // default: true
-  httpClient?: boolean | HttpClientOptions,
-  httpContext?: boolean, // default: true
-  inboundFilters?: boolean | InboundFiltersOptions, // default: true
-  linkedErrors?: boolean | LinkedErrorsOptions, // default: true
-  moduleMetadata?: boolean,
-  replay?: boolean | ReplayConfiguration,
-  reportingObserver?: boolean | ReportingObserverOptions,
-  rewriteFrames?: boolean | RewriteFramesOptions,
-  sessionTiming?: boolean,
-  tryCatch?: boolean | TryCatchOptions, // default: true
+sentry: {
+  enabled?: boolean // Default: Enabled in production
+  dsn: string,
+  clientSdk?: SdkConfig
+  disabledIntegrations?: Record<string, boolean>
 }
+```
+
+App config:
+
+```ts
+sentry: {
+  clientSdk?: (app: NuxtApp) => SdkConfig | SdkConfig
+  disabledIntegrations?: Record<string, boolean>
+}
+```
+
+### Configuring Integrations
+If you would like to enable or configure specific integrations or you would like to create custom integrations, you can do so by providing a `integrations` array in the `clientSdk` object in the `appConfig`. It's important to use the `appConfig` for this as integrations are not serializable and cannot be passed through the `runtimeConfig`.
+
+The list of integrations is deduplicated based on the `name` property of the integration so you can configure the default integrations by adding them to the list with the desired configuration.
+
+For example:
+
+```ts
+import { breadcrumbsIntegration } from "@sentry/vue"
+
+defineNuxtConfig({
+  appConfig: {
+    sentry: {
+      clientSdk: {
+        integrations: [
+          // Configure the default Breadcrumbs integration
+          breadcrumbIntegration({
+            console: true,
+            // Other options
+          }),
+          // Add a custom integration
+          new MyAwesomeIntegration()
+        ],
+      },
+    },
+  },
+})
 ```
 
 ## Development
@@ -138,10 +123,6 @@ npm run dev:build
 
 # Run ESLint
 npm run lint
-
-# Run Vitest
-npm run test
-npm run test:watch
 
 # Release new version
 npm run release

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "nuxt-module-build build",
+    "prepack": "nuxi prepare playground && nuxt-module-build build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "nuxi prepare playground && nuxt-module-build build",
+    "prepack": "nuxt-module-build build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "release": "npm run lint && npm run prepack && changelogen --release && npm publish && git push --follow-tags",
     "lint": "eslint .",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "typecheck": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
     "@nuxt/kit": "^3.11.2",
@@ -46,7 +47,8 @@
     "eslint-plugin-prettier": "^5.1.3",
     "nuxi": "^3.11.1",
     "nuxt": "^3.11.2",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "vue-tsc": "^2.0.16"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@binaryoverload/nuxt-sentry",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Nuxt 3 module for Sentry",
   "repository": "https://github.com/binaryoverload/nuxt-sentry",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,11 @@
     "nuxi": "^3.11.1",
     "nuxt": "^3.11.2",
     "prettier": "^3.2.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "@typescript-eslint/eslint-plugin": "^6.21.0",
+      "@typescript-eslint/parser": "^6.21.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         version: 0.3.10(eslint@8.57.0)(typescript@5.4.5)
       '@nuxt/module-builder':
         specifier: ^0.6.0
-        version: 0.6.0(@nuxt/kit@3.11.2)(nuxi@3.11.1)(typescript@5.4.5)
+        version: 0.6.0(@nuxt/kit@3.11.2)(nuxi@3.11.1)(typescript@5.4.5)(vue-tsc@2.0.16)
       '@nuxt/schema':
         specifier: ^3.11.2
         version: 3.11.2(rollup@3.29.4)
@@ -63,10 +63,13 @@ importers:
         version: 3.11.1
       nuxt:
         specifier: ^3.11.2
-        version: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)
+        version: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)(vue-tsc@2.0.16)
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
+      vue-tsc:
+        specifier: ^2.0.16
+        version: 2.0.16(typescript@5.4.5)
 
 packages:
 
@@ -1208,7 +1211,7 @@ packages:
       '@nuxt/kit': 3.11.2(rollup@3.29.4)
       '@nuxt/schema': 3.11.2(rollup@3.29.4)
       execa: 7.2.0
-      nuxt: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)
+      nuxt: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)(vue-tsc@2.0.16)
       vite: 5.2.11(@types/node@20.12.8)
     transitivePeerDependencies:
       - rollup
@@ -1260,7 +1263,7 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)
+      nuxt: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)(vue-tsc@2.0.16)
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 18.0.4
@@ -1368,7 +1371,7 @@ packages:
       - rollup
       - supports-color
 
-  /@nuxt/module-builder@0.6.0(@nuxt/kit@3.11.2)(nuxi@3.11.1)(typescript@5.4.5):
+  /@nuxt/module-builder@0.6.0(@nuxt/kit@3.11.2)(nuxi@3.11.1)(typescript@5.4.5)(vue-tsc@2.0.16):
     resolution: {integrity: sha512-d/sn+6n23qB+yGuItNvGnNlPpDzwcsW6riyISdo4H2MO/3TWFsIzB5+JZK104t0G6ftxB71xWHmBBYEdkXOhVw==}
     hasBin: true
     peerDependencies:
@@ -1383,7 +1386,7 @@ packages:
       nuxi: 3.11.1
       pathe: 1.1.2
       pkg-types: 1.1.0
-      unbuild: 2.0.0(typescript@5.4.5)
+      unbuild: 2.0.0(typescript@5.4.5)(vue-tsc@2.0.16)
     transitivePeerDependencies:
       - sass
       - supports-color
@@ -1511,7 +1514,7 @@ packages:
   /@nuxt/ui-templates@1.3.3:
     resolution: {integrity: sha512-3BG5doAREcD50dbKyXgmjD4b1GzY8CUy3T41jMhHZXNDdaNwOd31IBq+D6dV00OSrDVhzrTVj0IxsUsnMyHvIQ==}
 
-  /@nuxt/vite-builder@3.11.2(@types/node@20.12.8)(eslint@8.57.0)(rollup@3.29.4)(typescript@5.4.5)(vue@3.4.26):
+  /@nuxt/vite-builder@3.11.2(@types/node@20.12.8)(eslint@8.57.0)(rollup@3.29.4)(typescript@5.4.5)(vue-tsc@2.0.16)(vue@3.4.26):
     resolution: {integrity: sha512-eXTZsAAN4dPz4eA2UD5YU2kD/DqgfyQp1UYsIdCe6+PAVe1ifkUboBjbc0piR5+3qI/S/eqk3nzxRGbiYF7Ccg==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -1549,7 +1552,7 @@ packages:
       unplugin: 1.10.1
       vite: 5.2.11(@types/node@20.12.8)
       vite-node: 1.6.0(@types/node@20.12.8)
-      vite-plugin-checker: 0.6.4(eslint@8.57.0)(typescript@5.4.5)(vite@5.2.11)
+      vite-plugin-checker: 0.6.4(eslint@8.57.0)(typescript@5.4.5)(vite@5.2.11)(vue-tsc@2.0.16)
       vue: 3.4.26(typescript@5.4.5)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
@@ -3130,6 +3133,25 @@ packages:
       vue: 3.4.26(typescript@5.4.5)
     dev: true
 
+  /@volar/language-core@2.2.1:
+    resolution: {integrity: sha512-iHJAZKcYldZgyS8gx6DfIZApViVBeqbf6iPhqoZpG5A6F4zsZiFldKfwaKaBA3/wnOTWE2i8VUbXywI1WywCPg==}
+    dependencies:
+      '@volar/source-map': 2.2.1
+    dev: true
+
+  /@volar/source-map@2.2.1:
+    resolution: {integrity: sha512-w1Bgpguhbp7YTr7VUFu6gb4iAZjeEPsOX4zpgiuvlldbzvIWDWy4t0jVifsIsxZ99HAu+c3swiME7wt+GeNqhA==}
+    dependencies:
+      muggle-string: 0.4.1
+    dev: true
+
+  /@volar/typescript@2.2.1:
+    resolution: {integrity: sha512-Z/tqluR7Hz5/5dCqQp7wo9C/6tSv/IYl+tTzgzUt2NjTq95bKSsuO4E+V06D0c+3aP9x5S9jggLqw451hpnc6Q==}
+    dependencies:
+      '@volar/language-core': 2.2.1
+      path-browserify: 1.0.1
+    dev: true
+
   /@vue-macros/common@1.10.3(rollup@3.29.4)(vue@3.4.26):
     resolution: {integrity: sha512-YSgzcbXrRo8a/TF/YIguqEmTld1KA60VETKJG8iFuaAfj7j+Tbdin3cj7/cYbcCHORSq1v9IThgq7r8keH7LXQ==}
     engines: {node: '>=16.14.0'}
@@ -3327,6 +3349,24 @@ packages:
       - qrcode
       - sortablejs
       - universal-cookie
+    dev: true
+
+  /@vue/language-core@2.0.16(typescript@5.4.5):
+    resolution: {integrity: sha512-Bc2sexRH99pznOph8mLw2BlRZ9edm7tW51kcBXgx8adAoOcZUWJj3UNSsdQ6H9Y8meGz7BoazVrVo/jUukIsPw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@volar/language-core': 2.2.1
+      '@vue/compiler-dom': 3.4.26
+      '@vue/shared': 3.4.26
+      computeds: 0.0.1
+      minimatch: 9.0.4
+      path-browserify: 1.0.1
+      typescript: 5.4.5
+      vue-template-compiler: 2.7.16
     dev: true
 
   /@vue/reactivity@3.4.26:
@@ -4108,6 +4148,10 @@ packages:
       readable-stream: 4.5.2
     dev: true
 
+  /computeds@0.0.1:
+    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
+    dev: true
+
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -4403,6 +4447,10 @@ packages:
         optional: true
       drizzle-orm:
         optional: true
+    dev: true
+
+  /de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
     dev: true
 
   /debug@2.6.9:
@@ -5733,6 +5781,11 @@ packages:
       function-bind: 1.1.2
     dev: true
 
+  /he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+    dev: true
+
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -6674,7 +6727,7 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  /mkdist@1.5.1(typescript@5.4.5):
+  /mkdist@1.5.1(typescript@5.4.5)(vue-tsc@2.0.16):
     resolution: {integrity: sha512-lCu1spNiA52o7IaKgZnOjg28nNHwYqUDjBfXePXyUtzD7Xhe6rRTkGTalQ/ALfrZC/SrPw2+A/0qkeJ+fPDZtQ==}
     hasBin: true
     peerDependencies:
@@ -6705,6 +6758,7 @@ packages:
       postcss-nested: 6.0.1(postcss@8.4.38)
       semver: 7.6.0
       typescript: 5.4.5
+      vue-tsc: 2.0.16(typescript@5.4.5)
     dev: true
 
   /mlly@1.7.0:
@@ -6733,6 +6787,10 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
+
+  /muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
     dev: true
 
   /nanoid@3.3.7:
@@ -7047,7 +7105,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxt@3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11):
+  /nuxt@3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)(vue-tsc@2.0.16):
     resolution: {integrity: sha512-Be1d4oyFo60pdF+diBolYDcfNemoMYM3R8PDjhnGrs/w3xJoDH1YMUVWHXXY8WhSmYZI7dyBehx/6kTfGFliVA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -7066,7 +7124,7 @@ packages:
       '@nuxt/schema': 3.11.2(rollup@3.29.4)
       '@nuxt/telemetry': 2.5.4(rollup@3.29.4)
       '@nuxt/ui-templates': 1.3.3
-      '@nuxt/vite-builder': 3.11.2(@types/node@20.12.8)(eslint@8.57.0)(rollup@3.29.4)(typescript@5.4.5)(vue@3.4.26)
+      '@nuxt/vite-builder': 3.11.2(@types/node@20.12.8)(eslint@8.57.0)(rollup@3.29.4)(typescript@5.4.5)(vue-tsc@2.0.16)(vue@3.4.26)
       '@types/node': 20.12.8
       '@unhead/dom': 1.9.9
       '@unhead/ssr': 1.9.9
@@ -7455,6 +7513,10 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
     dev: true
 
   /path-exists@4.0.0:
@@ -9213,7 +9275,7 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /unbuild@2.0.0(typescript@5.4.5):
+  /unbuild@2.0.0(typescript@5.4.5)(vue-tsc@2.0.16):
     resolution: {integrity: sha512-JWCUYx3Oxdzvw2J9kTAp+DKE8df/BnH/JTSj6JyA4SH40ECdFu7FoJJcrm8G92B7TjofQ6GZGjJs50TRxoH6Wg==}
     hasBin: true
     peerDependencies:
@@ -9237,7 +9299,7 @@ packages:
       hookable: 5.5.3
       jiti: 1.21.0
       magic-string: 0.30.10
-      mkdist: 1.5.1(typescript@5.4.5)
+      mkdist: 1.5.1(typescript@5.4.5)(vue-tsc@2.0.16)
       mlly: 1.7.0
       pathe: 1.1.2
       pkg-types: 1.1.0
@@ -9618,7 +9680,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker@0.6.4(eslint@8.57.0)(typescript@5.4.5)(vite@5.2.11):
+  /vite-plugin-checker@0.6.4(eslint@8.57.0)(typescript@5.4.5)(vite@5.2.11)(vue-tsc@2.0.16):
     resolution: {integrity: sha512-2zKHH5oxr+ye43nReRbC2fny1nyARwhxdm0uNYp/ERy4YvU9iZpNOsueoi/luXw5gnpqRSvjcEPxXbS153O2wA==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -9667,6 +9729,7 @@ packages:
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
+      vue-tsc: 2.0.16(typescript@5.4.5)
     dev: true
 
   /vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2)(rollup@3.29.4)(vite@5.2.11):
@@ -9879,6 +9942,25 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.6.1
       vue: 3.4.26(typescript@5.4.5)
+    dev: true
+
+  /vue-template-compiler@2.7.16:
+    resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+    dev: true
+
+  /vue-tsc@2.0.16(typescript@5.4.5):
+    resolution: {integrity: sha512-/gHAWJa216PeEhfxtAToIbxdWgw01wuQzo48ZUqMYVEyNqDp+OYV9xMO5HaPS2P3Ls0+EsjguMZLY4cGobX4Ew==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@volar/typescript': 2.2.1
+      '@vue/language-core': 2.0.16(typescript@5.4.5)
+      semver: 7.6.0
+      typescript: 5.4.5
     dev: true
 
   /vue-virtual-scroller@2.0.0-beta.8(vue@3.4.26):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,63 +4,69 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  '@nuxt/kit':
-    specifier: ^3.11.2
-    version: 3.11.2(rollup@3.29.4)
-  '@sentry/vite-plugin':
-    specifier: ^2.16.1
-    version: 2.16.1
-  '@sentry/vue':
-    specifier: ^7.113.0
-    version: 7.113.0(vue@3.4.26)
-  defu:
-    specifier: ^6.1.4
-    version: 6.1.4
+overrides:
+  '@typescript-eslint/eslint-plugin': ^6.21.0
+  '@typescript-eslint/parser': ^6.21.0
 
-devDependencies:
-  '@nuxt/devtools':
-    specifier: ^1.2.0
-    version: 1.2.0(@unocss/reset@0.59.4)(floating-vue@5.2.2)(nuxt@3.11.2)(rollup@3.29.4)(unocss@0.59.4)(vite@5.2.11)(vue@3.4.26)
-  '@nuxt/eslint-config':
-    specifier: ^0.3.10
-    version: 0.3.10(eslint@8.57.0)(typescript@5.4.5)
-  '@nuxt/module-builder':
-    specifier: ^0.6.0
-    version: 0.6.0(@nuxt/kit@3.11.2)(nuxi@3.11.1)(typescript@5.4.5)
-  '@nuxt/schema':
-    specifier: ^3.11.2
-    version: 3.11.2(rollup@3.29.4)
-  '@nuxt/test-utils':
-    specifier: ^3.12.1
-    version: 3.12.1(h3@1.11.1)(rollup@3.29.4)(vite@5.2.11)(vue-router@4.3.2)(vue@3.4.26)
-  '@types/node':
-    specifier: ^20.12.8
-    version: 20.12.8
-  changelogen:
-    specifier: ^0.5.5
-    version: 0.5.5
-  eslint:
-    specifier: ^8.57.0
-    version: 8.57.0
-  eslint-config-prettier:
-    specifier: ^9.1.0
-    version: 9.1.0(eslint@8.57.0)
-  eslint-plugin-import:
-    specifier: ^2.29.1
-    version: 2.29.1(@typescript-eslint/parser@7.8.0)(eslint@8.57.0)
-  eslint-plugin-prettier:
-    specifier: ^5.1.3
-    version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
-  nuxi:
-    specifier: ^3.11.1
-    version: 3.11.1
-  nuxt:
-    specifier: ^3.11.2
-    version: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)
-  prettier:
-    specifier: ^3.2.5
-    version: 3.2.5
+importers:
+
+  .:
+    dependencies:
+      '@nuxt/kit':
+        specifier: ^3.11.2
+        version: 3.11.2(rollup@3.29.4)
+      '@sentry/vite-plugin':
+        specifier: ^2.16.1
+        version: 2.16.1
+      '@sentry/vue':
+        specifier: ^7.113.0
+        version: 7.113.0(vue@3.4.26)
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
+    devDependencies:
+      '@nuxt/devtools':
+        specifier: ^1.2.0
+        version: 1.2.0(@unocss/reset@0.59.4)(floating-vue@5.2.2)(nuxt@3.11.2)(rollup@3.29.4)(unocss@0.59.4)(vite@5.2.11)(vue@3.4.26)
+      '@nuxt/eslint-config':
+        specifier: ^0.3.10
+        version: 0.3.10(eslint@8.57.0)(typescript@5.4.5)
+      '@nuxt/module-builder':
+        specifier: ^0.6.0
+        version: 0.6.0(@nuxt/kit@3.11.2)(nuxi@3.11.1)(typescript@5.4.5)
+      '@nuxt/schema':
+        specifier: ^3.11.2
+        version: 3.11.2(rollup@3.29.4)
+      '@nuxt/test-utils':
+        specifier: ^3.12.1
+        version: 3.12.1(h3@1.11.1)(rollup@3.29.4)(vite@5.2.11)(vue-router@4.3.2)(vue@3.4.26)
+      '@types/node':
+        specifier: ^20.12.8
+        version: 20.12.8
+      changelogen:
+        specifier: ^0.5.5
+        version: 0.5.5
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
+      nuxi:
+        specifier: ^3.11.1
+        version: 3.11.1
+      nuxt:
+        specifier: ^3.11.2
+        version: 3.11.2(@opentelemetry/api@1.8.0)(@types/node@20.12.8)(@unocss/reset@0.59.4)(eslint@8.57.0)(floating-vue@5.2.2)(rollup@3.29.4)(typescript@5.4.5)(unocss@0.59.4)(vite@5.2.11)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.2.5
 
 packages:
 
@@ -1305,8 +1311,8 @@ packages:
       '@nuxt/eslint-plugin': 0.3.10(eslint@8.57.0)(typescript@5.4.5)
       '@rushstack/eslint-patch': 1.10.2
       '@stylistic/eslint-plugin': 1.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/eslint-plugin': 7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-config-flat-gitignore: 0.1.5
       eslint-flat-config-utils: 0.2.4
@@ -2624,23 +2630,23 @@ packages:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
+      '@typescript-eslint/parser': ^6.21.0
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 7.8.0
-      '@typescript-eslint/type-utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.8.0
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4
       eslint: 8.57.0
       graphemer: 1.4.0
@@ -2653,20 +2659,20 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  /@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 7.8.0
-      '@typescript-eslint/types': 7.8.0
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.8.0
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4
       eslint: 8.57.0
       typescript: 5.4.5
@@ -2690,18 +2696,18 @@ packages:
       '@typescript-eslint/visitor-keys': 7.8.0
     dev: true
 
-  /@typescript-eslint/type-utils@7.8.0(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  /@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 4.3.4
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
@@ -4883,7 +4889,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.1(@typescript-eslint/parser@7.8.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  /eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4904,7 +4910,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -4932,7 +4938,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.8.0)(eslint@8.57.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0)(eslint@8.57.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4942,7 +4948,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -4951,7 +4957,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.8.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,7 @@
 import type { ModuleOptions } from "./types"
 import type { Plugin } from "vite"
 
-import {
-  addPlugin,
-  addTypeTemplate,
-  addVitePlugin,
-  createResolver,
-  defineNuxtModule,
-} from "@nuxt/kit"
+import { addPlugin, addVitePlugin, createResolver, defineNuxtModule } from "@nuxt/kit"
 import { useLogger } from "@nuxt/kit"
 import { type SentryVitePluginOptions, sentryVitePlugin } from "@sentry/vite-plugin"
 import defu from "defu"
@@ -59,10 +53,5 @@ export default defineNuxtModule<ModuleOptions>({
     addVitePlugin(() => sentryVitePlugin(defu(moduleOptions.vitePlugin, defaults)) as Plugin)
 
     addPlugin(resolver.resolve("./runtime/sentry.client"))
-
-    addTypeTemplate({
-      filename: "types/nuxt-sentry.d.ts",
-      src: resolver.resolve("./module.d.ts"),
-    })
   },
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,13 @@
 import type { ModuleOptions } from "./types"
 import type { Plugin } from "vite"
 
-import { addPlugin, addVitePlugin, createResolver, defineNuxtModule } from "@nuxt/kit"
+import {
+  addPlugin,
+  addTypeTemplate,
+  addVitePlugin,
+  createResolver,
+  defineNuxtModule,
+} from "@nuxt/kit"
 import { useLogger } from "@nuxt/kit"
 import { type SentryVitePluginOptions, sentryVitePlugin } from "@sentry/vite-plugin"
 import defu from "defu"
@@ -12,6 +18,9 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: "@binaryoverload/nuxt-sentry",
     configKey: "sentry",
+    compatibility: {
+      nuxt: "^3.0.0",
+    },
   },
 
   async setup(_moduleOptions, nuxt) {
@@ -48,5 +57,10 @@ export default defineNuxtModule<ModuleOptions>({
     addVitePlugin(() => sentryVitePlugin(defu(moduleOptions.vitePlugin, defaults)) as Plugin)
 
     addPlugin(resolver.resolve("./runtime/sentry.client"))
+
+    addTypeTemplate({
+      filename: "types/nuxt-sentry.d.ts",
+      src: resolver.resolve("./module.d.ts"),
+    })
   },
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,10 +24,12 @@ export default defineNuxtModule<ModuleOptions>({
   },
 
   async setup(_moduleOptions, nuxt) {
-    if (!nuxt.options.runtimeConfig.public.sentry?.dsn) {
-      logger.warn("No Sentry DSN provided. Provide it in `runtimeConfig.public.sentry.dsn`")
+    if (_moduleOptions.enabled === false) {
+      logger.warn("Sentry module is disabled")
       return
     }
+
+    logger.info("Setting up Sentry module")
 
     const moduleOptions = defu(_moduleOptions, {
       deleteSourcemapsAfterUpload: true,

--- a/src/runtime/sentry.client.ts
+++ b/src/runtime/sentry.client.ts
@@ -20,10 +20,10 @@ export default defineNuxtPlugin({
 
     const enabled = runtimeSentryConfig?.enabled ?? !process.dev
     const dsn = runtimeSentryConfig?.dsn
-    const runtimeSdkConfig = runtimeSentryConfig?.sdk
+    const runtimeSdkConfig = runtimeSentryConfig?.clientSdk
     const runtimeDisableIntegrations = runtimeSentryConfig?.disableIntegrations ?? {}
 
-    const appSdkConfig = appSentryConfig?.sdk
+    const appSdkConfig = appSentryConfig?.clientSdk
     const appConfig =
       typeof appSdkConfig === "function" ? appSdkConfig(nuxt.vueApp.$nuxt) : appSdkConfig
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,29 +5,31 @@ import type { NuxtApp } from "nuxt/app"
 export type SentryConfig = Partial<Omit<SentryVueOptions, "Vue" | "app" | "dsn">>
 
 export interface DisableIntegrationConfig {
-  Breadcrumbs?: true
-  BrowserTracing?: true
-  CaptureConsole?: true
-  ContextLines?: true
-  Debug?: true
-  Dedupe?: true
-  ExtraErrorData?: true
-  FunctionToString?: true
-  GlobalHandlers?: true
-  HttpClient?: true
-  HttpContext?: true
-  InboundFilters?: true
-  LinkedErrors?: true
-  ModuleMetadata?: true
-  Replay?: true
-  ReportingObserver?: true
-  RewriteFrames?: true
-  SessionTiming?: true
-  TryCatch?: true
-  [key: string]: true | undefined
+  Breadcrumbs?: boolean
+  BrowserTracing?: boolean
+  CaptureConsole?: boolean
+  ContextLines?: boolean
+  Debug?: boolean
+  Dedupe?: boolean
+  ExtraErrorData?: boolean
+  FunctionToString?: boolean
+  GlobalHandlers?: boolean
+  HttpClient?: boolean
+  HttpContext?: boolean
+  InboundFilters?: boolean
+  LinkedErrors?: boolean
+  ModuleMetadata?: boolean
+  Replay?: boolean
+  ReportingObserver?: boolean
+  RewriteFrames?: boolean
+  SessionTiming?: boolean
+  TryCatch?: boolean
+  [key: string]: boolean | undefined
 }
 
 export interface ModuleOptions {
+  /** @default true */
+  enabled?: boolean
   /** @default true */
   deleteSourcemapsAfterUpload?: boolean
   vitePlugin: SentryVitePluginOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,73 @@
 import type { SentryVitePluginOptions } from "@sentry/vite-plugin"
-import type { BrowserTracing, Integrations, Replay } from "@sentry/vue"
 import type { Options as SentryVueOptions } from "@sentry/vue/types/types"
 import type { NuxtApp } from "nuxt/app"
 
+import {
+  breadcrumbsIntegration,
+  browserApiErrorsIntegration,
+  browserProfilingIntegration,
+  browserTracingIntegration,
+  captureConsoleIntegration,
+  contextLinesIntegration,
+  debugIntegration,
+  dedupeIntegration,
+  extraErrorDataIntegration,
+  functionToStringIntegration,
+  globalHandlersIntegration,
+  httpClientIntegration,
+  httpContextIntegration,
+  inboundFiltersIntegration,
+  linkedErrorsIntegration,
+  moduleMetadataIntegration,
+  replayIntegration,
+  reportingObserverIntegration,
+  rewriteFramesIntegration,
+  sessionTimingIntegration,
+} from "@sentry/vue"
+
 export type SentryConfig = Partial<Omit<SentryVueOptions, "Vue" | "app" | "dsn">>
-export type SentryIntegrations = {
-  [key in keyof typeof Integrations]?: IntegrationOptions<(typeof Integrations)[key]> | false
-} & {
-  Replay: IntegrationOptions<typeof Replay> | false
-  BrowserTracing: IntegrationOptions<typeof BrowserTracing> | false
-  BrowserProfiling: boolean
+
+export const integrationMap = {
+  breadcrumbs: breadcrumbsIntegration,
+  browserTracing: browserTracingIntegration,
+  browserProfiling: browserProfilingIntegration,
+  captureConsole: captureConsoleIntegration,
+  contextLines: contextLinesIntegration,
+  debug: debugIntegration,
+  dedupe: dedupeIntegration,
+  extraErrorData: extraErrorDataIntegration,
+  functionToString: functionToStringIntegration,
+  globalHandlers: globalHandlersIntegration,
+  httpClient: httpClientIntegration,
+  httpContext: httpContextIntegration,
+  inboundFilters: inboundFiltersIntegration,
+  linkedErrors: linkedErrorsIntegration,
+  moduleMetadata: moduleMetadataIntegration,
+  replay: replayIntegration,
+  reportingObserver: reportingObserverIntegration,
+  rewriteFrames: rewriteFramesIntegration,
+  sessionTiming: sessionTimingIntegration,
+  tryCatch: browserApiErrorsIntegration,
+} as const
+
+export const defaultIntegrations: (keyof typeof integrationMap)[] = [
+  "breadcrumbs",
+  "dedupe",
+  "functionToString",
+  "globalHandlers",
+  "httpContext",
+  "inboundFilters",
+  "linkedErrors",
+  "tryCatch",
+]
+
+export type IntegrationOptions = {
+  [key in keyof typeof integrationMap]?: IntegrationOptionExtract<(typeof integrationMap)[key]>
 }
 
-type IntegrationOptions<T extends abstract new (...args: any) => any> =
-  ConstructorParameters<T>[0] extends infer P ? (undefined extends P ? P | true : P) : never
+type IntegrationOptionExtract<T extends (...args: any) => any> = Parameters<T>[0] extends infer P
+  ? Exclude<P, undefined> | boolean
+  : never
 
 export interface ModuleOptions {
   /** @default true */
@@ -24,13 +78,13 @@ export interface ModuleOptions {
 export interface RuntimeConfig {
   dsn: string
   enabled?: boolean
-  integrations?: SentryIntegrations
+  integrations?: IntegrationOptions
   sdk?: SentryConfig
 }
 
 export interface AppConfig {
   sdk?: SentryConfig | ((app: NuxtApp) => SentryConfig)
-  integrations?: SentryIntegrations
+  integrations?: IntegrationOptions
 }
 
 declare module "@nuxt/schema" {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,72 +2,30 @@ import type { SentryVitePluginOptions } from "@sentry/vite-plugin"
 import type { Options as SentryVueOptions } from "@sentry/vue/types/types"
 import type { NuxtApp } from "nuxt/app"
 
-import {
-  breadcrumbsIntegration,
-  browserApiErrorsIntegration,
-  browserProfilingIntegration,
-  browserTracingIntegration,
-  captureConsoleIntegration,
-  contextLinesIntegration,
-  debugIntegration,
-  dedupeIntegration,
-  extraErrorDataIntegration,
-  functionToStringIntegration,
-  globalHandlersIntegration,
-  httpClientIntegration,
-  httpContextIntegration,
-  inboundFiltersIntegration,
-  linkedErrorsIntegration,
-  moduleMetadataIntegration,
-  replayIntegration,
-  reportingObserverIntegration,
-  rewriteFramesIntegration,
-  sessionTimingIntegration,
-} from "@sentry/vue"
-
 export type SentryConfig = Partial<Omit<SentryVueOptions, "Vue" | "app" | "dsn">>
 
-export const integrationMap = {
-  breadcrumbs: breadcrumbsIntegration,
-  browserTracing: browserTracingIntegration,
-  browserProfiling: browserProfilingIntegration,
-  captureConsole: captureConsoleIntegration,
-  contextLines: contextLinesIntegration,
-  debug: debugIntegration,
-  dedupe: dedupeIntegration,
-  extraErrorData: extraErrorDataIntegration,
-  functionToString: functionToStringIntegration,
-  globalHandlers: globalHandlersIntegration,
-  httpClient: httpClientIntegration,
-  httpContext: httpContextIntegration,
-  inboundFilters: inboundFiltersIntegration,
-  linkedErrors: linkedErrorsIntegration,
-  moduleMetadata: moduleMetadataIntegration,
-  replay: replayIntegration,
-  reportingObserver: reportingObserverIntegration,
-  rewriteFrames: rewriteFramesIntegration,
-  sessionTiming: sessionTimingIntegration,
-  tryCatch: browserApiErrorsIntegration,
-} as const
-
-export const defaultIntegrations: (keyof typeof integrationMap)[] = [
-  "breadcrumbs",
-  "dedupe",
-  "functionToString",
-  "globalHandlers",
-  "httpContext",
-  "inboundFilters",
-  "linkedErrors",
-  "tryCatch",
-]
-
-export type IntegrationOptions = {
-  [key in keyof typeof integrationMap]?: IntegrationOptionExtract<(typeof integrationMap)[key]>
+export interface DisableIntegrationConfig {
+  Breadcrumbs?: true
+  BrowserTracing?: true
+  CaptureConsole?: true
+  ContextLines?: true
+  Debug?: true
+  Dedupe?: true
+  ExtraErrorData?: true
+  FunctionToString?: true
+  GlobalHandlers?: true
+  HttpClient?: true
+  HttpContext?: true
+  InboundFilters?: true
+  LinkedErrors?: true
+  ModuleMetadata?: true
+  Replay?: true
+  ReportingObserver?: true
+  RewriteFrames?: true
+  SessionTiming?: true
+  TryCatch?: true
+  [key: string]: true | undefined
 }
-
-type IntegrationOptionExtract<T extends (...args: any) => any> = Parameters<T>[0] extends infer P
-  ? Exclude<P, undefined> | boolean
-  : never
 
 export interface ModuleOptions {
   /** @default true */
@@ -78,13 +36,12 @@ export interface ModuleOptions {
 export interface RuntimeConfig {
   dsn: string
   enabled?: boolean
-  integrations?: IntegrationOptions
+  disableIntegrations?: DisableIntegrationConfig
   sdk?: SentryConfig
 }
 
 export interface AppConfig {
   sdk?: SentryConfig | ((app: NuxtApp) => SentryConfig)
-  integrations?: IntegrationOptions
 }
 
 declare module "@nuxt/schema" {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,11 +37,11 @@ export interface RuntimeConfig {
   dsn: string
   enabled?: boolean
   disableIntegrations?: DisableIntegrationConfig
-  sdk?: SentryConfig
+  clientSdk?: SentryConfig
 }
 
 export interface AppConfig {
-  sdk?: SentryConfig | ((app: NuxtApp) => SentryConfig)
+  clientSdk?: SentryConfig | ((app: NuxtApp) => SentryConfig)
 }
 
 declare module "@nuxt/schema" {


### PR DESCRIPTION
 - Use `integrations` option in SDK config instead of runtime config
   - To add additional integrations and configure options, the `sdk.integrations` key can be configured in either app config or runtime config
- Integrations can be disabled using the `disabledIntegrations` key in the runtime config by setting the integrations name to false